### PR TITLE
Add check for alt key.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -219,6 +219,9 @@ extern "C" __declspec(dllexport) char setPlayerCifStatus(bool p2, char v) {
 }
 
 bool checkKey(unsigned char scancode) { return ((char *)0x8a01b8)[scancode]; }
+bool checkNoModKeys() { 
+  return !checkKey(DIK_LALT) && !checkKey(DIK_RALT) && !GetAsyncKeyState(VK_MENU);
+}
 
 static std::atomic<std::chrono::system_clock::time_point> othersChangedTime;
 static std::chrono::system_clock::duration selectOthersChangedDuration;
@@ -369,7 +372,7 @@ int __fastcall myBattleOnProcess(T *This) {
   if (switchByKey && checkKey(switchKey)) {
     selfCifChangedTime = std::chrono::system_clock::now();
     if (!lastPress) {
-      if (!isNetplay) {
+      if (!isNetplay && !checkNoModKeys()) {
         lastPress = true;
         status = !status;
         preference = status;
@@ -398,7 +401,7 @@ int __fastcall mySelectOnProcess(T *This) {
     lastBattleMode = SokuLib::mainMode;
   }
   bool status = preference;
-  if (switchByKey && checkKey(switchKey)) {
+  if (switchByKey && checkKey(switchKey) && checkNoModKeys()) {
     selfCifChangedTime = std::chrono::system_clock::now();
     if (!lastPress) {
       auto This_ = (SokuLib::Select *)This;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -369,10 +369,10 @@ int __fastcall myBattleOnProcess(T *This) {
     lastBattleMode = SokuLib::mainMode;
   }
   bool status = preference;
-  if (switchByKey && checkKey(switchKey)) {
+  if (switchByKey && checkKey(switchKey) && !checkNoModKeys()) {
     selfCifChangedTime = std::chrono::system_clock::now();
     if (!lastPress) {
-      if (!isNetplay && !checkNoModKeys()) {
+      if (!isNetplay) {
         lastPress = true;
         status = !status;
         preference = status;


### PR DESCRIPTION
Only checking the two alt keys in case checking all 8 mod keys affects performance.
Checking the DIK array and GetAsyncState seem to cover almost all cases. 
Doing it properly would require hooking wndproc.